### PR TITLE
Fix os-release parser capturing only the last character of quoted values

### DIFF
--- a/deptective/package_manager.py
+++ b/deptective/package_manager.py
@@ -12,7 +12,32 @@ from .containers import DockerContainer
 T = TypeVar("T")
 
 
+_OS_RELEASE_LINE = re.compile(
+    r'\s*(?P<var>\S+)\s*=\s*'
+    r'("(?P<quoted>[^"]*)"|\'(?P<singlequoted>[^\']*)\'|(?P<unquoted>\S*))\s*'
+)
+
+
+def parse_os_release_line(line: str) -> "Optional[Tuple[str, str]]":
+    """Parse a single os-release line into a (lowercased var, value) pair.
+
+    Handles double-quoted, single-quoted, and unquoted values. Returns None
+    for lines that do not match a ``VAR=value`` assignment.
+    """
+    m = _OS_RELEASE_LINE.match(line.strip())
+    if m is None:
+        return None
+    if m["quoted"] is not None:
+        value = m["quoted"]
+    elif m["singlequoted"] is not None:
+        value = m["singlequoted"]
+    else:
+        value = m["unquoted"]
+    return m["var"].lower(), value
+
+
 @dataclass(eq=True, frozen=True, unsafe_hash=True)
+
 class PackagingConfig:
     os: str
     os_version: str
@@ -26,36 +51,20 @@ class PackagingConfig:
         arch = platform.machine().lower()
         os_release_path = Path("/etc/os-release")
         if os_release_path.exists():
-            var_pattern = re.compile(
-                r"\s*(?P<var>\S+)\s*=\s*(\"(?P<quoted>[^\"])*\"|(?P<unquoted>\S*)|\'(?P<singlequoted>[^\'])*\')\s*"
-            )
             version_id: Optional[str] = None
             version_codename: Optional[str] = None
             with open(os_release_path, "r") as f:
                 for line in f:
-                    line = line.strip()
-                    m = var_pattern.match(line)
-                    if m:
-                        var = m["var"].lower()
-                        quoted, unquoted, singlequoted = (
-                            m["quoted"],
-                            m["unquoted"],
-                            m["singlequoted"],
-                        )
-                        if quoted is not None:
-                            value = quoted
-                        elif unquoted is not None:
-                            value = unquoted
-                        elif singlequoted is not None:
-                            value = singlequoted
-                        else:
-                            continue
-                        if var == "id":
-                            local_os = value
-                        elif var == "version_id":
-                            version_id = value
-                        elif var == "version_codename":
-                            version_codename = value
+                    parsed = parse_os_release_line(line)
+                    if parsed is None:
+                        continue
+                    var, value = parsed
+                    if var == "id":
+                        local_os = value
+                    elif var == "version_id":
+                        version_id = value
+                    elif var == "version_codename":
+                        version_codename = value
             if version_codename:
                 local_release = version_codename
             elif version_id:

--- a/test/test_os_release.py
+++ b/test/test_os_release.py
@@ -1,0 +1,20 @@
+from deptective.package_manager import parse_os_release_line
+
+
+def test_quoted_values_keep_full_value():
+    assert parse_os_release_line('ID="ubuntu"') == ("id", "ubuntu")
+    assert parse_os_release_line('VERSION_ID="22.04"') == ("version_id", "22.04")
+    assert parse_os_release_line('PRETTY_NAME="Ubuntu 22.04.3 LTS"') == (
+        "pretty_name",
+        "Ubuntu 22.04.3 LTS",
+    )
+
+
+def test_single_and_unquoted_values():
+    assert parse_os_release_line("VERSION_ID='22.04'") == ("version_id", "22.04")
+    assert parse_os_release_line("VERSION_CODENAME=jammy") == ("version_codename", "jammy")
+
+
+def test_non_assignment_returns_none():
+    assert parse_os_release_line("# a comment") is None
+    assert parse_os_release_line("") is None


### PR DESCRIPTION
The `/etc/os-release` line pattern in `PackagingConfig.get_local` places the `*` quantifier outside the capture group:

```python
r"\s*(?P<var>\S+)\s*=\s*(\"(?P<quoted>[^\"])*\"|(?P<unquoted>\S*)|\'(?P<singlequoted>[^\'])*\')\s*"
```

Because `(?P<quoted>[^\"])*` repeats the group, it rebinds on every iteration and keeps only the last matched character. On a normal host:

- `ID="ubuntu"` becomes `"u"`
- `VERSION_ID="22.04"` becomes `"4"`

There is a second issue: the `unquoted` alternative precedes the single-quote alternative and its `\S*` greedily consumes a single-quoted value including the quotes, so the `singlequoted` branch is dead.

These values flow into the apt Contents-DB URL, the Docker base-image tag, and the cache key, so they get corrupted to single characters (the `VERSION_ID` case is masked when an unquoted `VERSION_CODENAME` is present, since codename is preferred, but a quoted `ID` is not).

Fix: move the quantifiers inside the groups and order the quoted alternatives before the unquoted one. I also extracted a small `parse_os_release_line` helper so this is unit-testable without touching `/etc/os-release`. Added `test/test_os_release.py`; ran it under Python 3.13 (3 passing), and confirmed the old pattern returns the last-character values.

Thanks!
